### PR TITLE
Remove use of fingerprints from parsers

### DIFF
--- a/datasets/cz_business_register/parse.py
+++ b/datasets/cz_business_register/parse.py
@@ -1,8 +1,8 @@
 import tarfile
+from normality import slugify
 from io import BufferedReader
 from typing import Optional
 
-from fingerprints import generate as fp
 from followthemoney.util import make_entity_id
 from lxml import etree
 from nomenklatura.entity import CE
@@ -18,13 +18,13 @@ def company_id(
 ) -> Optional[str]:
     if reg_nr:
         return f"oc-companies-cz-{reg_nr}"
-    return context.make_slug("company", fp(name))
+    return context.make_slug("company", name)
 
 
 def person_id(context: Zavod, name: str, address: str, company_id: str) -> str:
-    if fp(address):
-        return context.make_slug("person", fp(name), make_entity_id(fp(address)))
-    return context.make_slug("person", fp(name), make_entity_id(company_id))
+    if slugify(address) is not None:
+        return context.make_slug("person", name, make_entity_id(address))
+    return context.make_slug("person", name, make_entity_id(company_id))
 
 
 def make_address(tree: Optional[ElementOrTree] = None) -> Optional[str]:

--- a/datasets/de_offeneregister/parse.py
+++ b/datasets/de_offeneregister/parse.py
@@ -4,7 +4,6 @@ from functools import lru_cache
 from typing import Any, Optional
 
 import orjson
-from fingerprints import generate as fp
 from followthemoney.util import join_text, make_entity_id
 from nomenklatura.entity import CE
 from zavod import Zavod, init_context
@@ -115,18 +114,16 @@ def make_officer_and_rel(context: Zavod, company: CE, data: dict[str, Any]):
             rel_summary = parsed_data.pop("summary")
         else:
             proxy.add("name", name)
-            proxy.id = context.make_slug(
-                "officer", make_entity_id(company.id, fp(name))
-            )
+            proxy.id = context.make_slug("officer", make_entity_id(company.id, name))
     elif type_ == "person":
         proxy = context.make("Person")
         proxy.add("name", name)
-        proxy.id = context.make_slug("officer", make_entity_id(company.id, fp(name)))
+        proxy.id = context.make_slug("officer", make_entity_id(company.id, name))
     else:
         context.log.warning("Unknown type: %s" % type_)
         proxy = context.make("LegalEntity")
         proxy.add("name", name)
-        proxy.id = context.make_slug("officer", make_entity_id(company.id, fp(name)))
+        proxy.id = context.make_slug("officer", make_entity_id(company.id, name))
 
     for key, value in data.get("other_attributes", {}).items():
         if key in MAPPING:

--- a/datasets/ee_ariregister/parse.py
+++ b/datasets/ee_ariregister/parse.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import Any, Callable, Optional, Tuple
 
 import ijson
-from fingerprints import generate as fp
 from followthemoney.util import make_entity_id
 from nomenklatura.entity import CE
 from zavod import Zavod, init_context
@@ -87,10 +86,10 @@ def make_officer(context: Zavod, data: dict, company_id: str) -> CE:
     address = get_address(data)
     proxy.id = context.make_slug(id_number)
     if proxy.id is None:
-        ident_id = make_entity_id(fp(address))
+        ident_id = make_entity_id(address)
         if ident_id is None:
             ident_id = id_number or company_id
-        proxy.id = context.make_slug("officer", fp(proxy.caption), ident_id)
+        proxy.id = context.make_slug("officer", proxy.caption, ident_id)
 
     proxy.add("registrationNumber", id_number)
     proxy.add("country", data.pop("aadress_riik"))
@@ -104,7 +103,7 @@ def make_rel(
 ) -> CE:
     rel = context.make(schema)
     rel.id = context.make_slug(
-        rel.schema.name, company.id, officer.id, fp(role), strict=False
+        rel.schema.name, company.id, officer.id, role, strict=False
     )
     rel.add("startDate", parse_date(data.pop("algus_kpv")))
     rel.add("endDate", parse_date(data.pop("lopp_kpv")))

--- a/datasets/lv_business_register/parse.py
+++ b/datasets/lv_business_register/parse.py
@@ -1,7 +1,6 @@
 import csv
 from typing import Optional
 
-from fingerprints import generate as fp
 from zavod import Zavod, init_context
 
 TYPES = {
@@ -19,7 +18,7 @@ def company_id(
     if reg_nr:
         return f"oc-companies-lv-{reg_nr}".lower()
     if name is not None:
-        return context.make_slug("company", fp(name))
+        return context.make_slug("company", name)
     context.log.warn("No id for company")
 
 

--- a/datasets/us_corpwatch/parse.py
+++ b/datasets/us_corpwatch/parse.py
@@ -1,8 +1,8 @@
 import csv
 from pathlib import Path
+from normality import slugify
 from typing import Callable, Optional, Union
 
-from fingerprints import generate as fp
 from nomenklatura.entity import CE
 from zavod import Zavod, init_context
 from zavod.parse.addresses import format_line
@@ -77,7 +77,8 @@ def parse_company_locations(context: Zavod, row: dict):
             state=clean(row.pop("state")),
             country_code=country_code.lower(),
         )
-        if fp(address):  # don't add addresses consisting only of placeholder characters
+        # don't add addresses consisting only of placeholder characters:
+        if slugify(address) is not None:
             proxy.add("address", address)
         context.emit(proxy)
 


### PR DESCRIPTION
Hey @simonwoerpel I noticed that we've been using fingerprints to make entity IDs. This should be largely unnecessary if the next thing to do is calling `make_slug` (which does many of the same things), but it's also a super unstable things to do because `fingerprints` is not meant to produce stable results over time, just name versions more suited for comparison. I'm therefore suggesting to remove this. Can you have a think if this is making things considerably worse?